### PR TITLE
feat: Add background color setting with text contrast

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, jsonify, render_template, request
+from flask import Flask, jsonify, render_template, request, session
 import json
 import os
 import datetime
@@ -6,6 +6,7 @@ import pytz # For timezone handling
 import re # For simple tokenization and keyword extraction
 
 app = Flask(__name__)
+app.secret_key = os.urandom(24) # Or a fixed secret string for development
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_FILE = os.path.join(BASE_DIR, "../data/scraped_data.json")
@@ -155,6 +156,18 @@ def handle_query():
         app.logger.error(f"Error in /api/query: {e}", exc_info=True) # Log the full error
         return jsonify({"error": "An internal error occurred processing your query: " + str(e)}), 500
 
+@app.route('/api/settings', methods=['GET', 'POST'])
+def manage_settings():
+    if request.method == 'POST':
+        data = request.get_json()
+        if data and 'background_color' in data:
+            session['background_color'] = data['background_color']
+            return jsonify({"message": "Settings saved successfully.", "background_color": data['background_color']})
+        return jsonify({"error": "Invalid data. 'background_color' missing."}), 400
+
+    if request.method == 'GET':
+        background_color = session.get('background_color', '#FFFFFF') # Default to white if not set
+        return jsonify({"background_color": background_color})
 
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0', port=5000)

--- a/webapp/static/script.js
+++ b/webapp/static/script.js
@@ -5,9 +5,12 @@ document.addEventListener('DOMContentLoaded', function() {
     const settingsModal = document.getElementById('settings-modal');
     const closeModalButton = settingsModal.querySelector('.close-button');
     const timezoneInput = document.getElementById('timezone-input');
-    const saveSettingsButton = document.getElementById('save-settings');
-    const settingsMessage = document.getElementById('settings-message');
+    const saveSettingsButton = document.getElementById('save-settings'); // This ID is in the HTML for the main save button in the modal
+    const settingsMessage = document.getElementById('settings-message'); // This ID is in the HTML
     const queryInput = document.getElementById('query-input');
+    // --- New Elements for Background Settings ---
+    const backgroundColorPicker = document.getElementById('backgroundColorPicker');
+    const backgroundColorHex = document.getElementById('backgroundColorHex');
     const submitQueryButton = document.getElementById('submit-query');
     const resultsArea = document.getElementById('results-area');
     const scrapedDataPreviewArea = document.getElementById('scraped-data-preview'); // New area to populate
@@ -20,6 +23,7 @@ document.addEventListener('DOMContentLoaded', function() {
         timezoneInput.value = currentTz || '';
         settingsMessage.textContent = '';
         settingsModal.style.display = 'flex';
+        loadAppearanceSettings(); // Load current appearance settings when modal opens
     }
 
     function closeSettingsModal() {
@@ -52,28 +56,138 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     async function handleSaveSettings() {
+        // Timezone Saving Part (existing logic)
+        let timezoneSaved = false;
         const newTimezone = timezoneInput.value.trim();
-        if (!newTimezone) {
-            settingsMessage.textContent = 'Please enter a timezone or city name.';
-            settingsMessage.style.color = 'red'; return;
-        }
-        try {
-            const validationResponse = await fetch(`/api/validate_timezone?tz=${encodeURIComponent(newTimezone)}`);
-            const validationData = await validationResponse.json();
-            if (!validationResponse.ok || !validationData.is_valid) {
-                settingsMessage.textContent = validationData.error || 'Invalid timezone (e.g., "America/New_York").';
-                settingsMessage.style.color = 'red'; return;
+        if (newTimezone) { // Only save if there's a value, allowing users to only save appearance
+            try {
+                const validationResponse = await fetch(`/api/validate_timezone?tz=${encodeURIComponent(newTimezone)}`);
+                const validationData = await validationResponse.json();
+                if (!validationResponse.ok || !validationData.is_valid) {
+                    settingsMessage.textContent = validationData.error || 'Invalid timezone (e.g., "America/New_York").';
+                    settingsMessage.style.color = 'red';
+                    // Do not return yet, try saving appearance settings
+                } else {
+                    localStorage.setItem(TIMEZONE_KEY, newTimezone);
+                    fetchAndUpdateTime(); // Update time immediately
+                    timezoneSaved = true;
+                }
+            } catch (error) {
+                console.error("Error validating timezone:", error);
+                settingsMessage.textContent = 'Could not validate timezone. Appearance settings might still be saved.';
+                settingsMessage.style.color = 'red';
             }
-            localStorage.setItem(TIMEZONE_KEY, newTimezone);
-            settingsMessage.textContent = 'Settings saved!';
-            settingsMessage.style.color = 'green';
-            fetchAndUpdateTime();
-            setTimeout(closeSettingsModal, 1000);
-        } catch (error) {
-            console.error("Error validating timezone:", error);
-            settingsMessage.textContent = 'Could not validate timezone.';
-            settingsMessage.style.color = 'red';
         }
+
+        // Appearance Saving Part (new logic)
+        let appearanceSaved = await saveAppearanceSettings();
+
+        if (timezoneSaved && appearanceSaved) {
+            settingsMessage.textContent = 'All settings saved!';
+            settingsMessage.style.color = 'green';
+            setTimeout(closeSettingsModal, 1500);
+        } else if (timezoneSaved) {
+            settingsMessage.textContent = 'Timezone saved! (Appearance not saved or no change)';
+            settingsMessage.style.color = 'green';
+            setTimeout(closeSettingsModal, 1500);
+        } else if (appearanceSaved) {
+            // Message for appearance saved is handled by saveAppearanceSettings
+            setTimeout(closeSettingsModal, 1500);
+        } else if (!newTimezone && !appearanceSaved) {
+             settingsMessage.textContent = 'No changes to save.';
+             settingsMessage.style.color = 'orange';
+        }
+        // If only one failed, specific error message would have been set by the failed function
+    }
+
+    // --- New Functions for Appearance Settings ---
+    function getContrastingTextColor(hexColor) {
+        if (!hexColor) return '#000000';
+        const hex = hexColor.replace('#', '');
+        const r = parseInt(hex.substring(0, 2), 16);
+        const g = parseInt(hex.substring(2, 4), 16);
+        const b = parseInt(hex.substring(4, 6), 16);
+        const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+        return luminance > 0.5 ? '#000000' : '#FFFFFF';
+    }
+
+    function applySettings(bgColor) {
+        document.body.style.backgroundColor = bgColor;
+        const textColor = getContrastingTextColor(bgColor);
+        document.body.style.color = textColor;
+        // Example for specific elements:
+        // document.querySelectorAll('.card, .modal-content, .app-header').forEach(el => {
+        // el.style.borderColor = textColor === '#000000' ? 'rgba(0,0,0,0.1)' : 'rgba(255,255,255,0.2)';
+        // });
+        // More targeted styling might be needed for specific components to ensure readability
+    }
+
+    async function loadAppearanceSettings() {
+        try {
+            const response = await fetch('/api/settings');
+            if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+            const settings = await response.json();
+            if (settings.background_color) {
+                applySettings(settings.background_color);
+                if (backgroundColorPicker) backgroundColorPicker.value = settings.background_color;
+                if (backgroundColorHex) backgroundColorHex.value = settings.background_color;
+            }
+        } catch (error) {
+            console.error("Error loading appearance settings:", error);
+            // Don't show modal message here, as it might be confusing during initial page load
+        }
+    }
+
+    async function saveAppearanceSettings() {
+        const colorToSave = backgroundColorHex.value.trim() || backgroundColorPicker.value;
+        if (!colorToSave.match(/^#[0-9a-fA-F]{6}$/i) && !colorToSave.match(/^#[0-9a-fA-F]{3}$/i) ) {
+            if(backgroundColorHex.value.trim()){ // only show error if user typed something invalid
+                 settingsMessage.textContent = 'Invalid HEX color format (e.g., #RRGGBB).';
+                 settingsMessage.style.display = 'block';
+                 settingsMessage.style.color = 'red';
+            }
+            return false; // Indicate save failed or no valid color to save
+        }
+
+        try {
+            const response = await fetch('/api/settings', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ background_color: colorToSave }),
+            });
+            if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+            const result = await response.json();
+            applySettings(colorToSave);
+            if (settingsMessage) {
+                settingsMessage.textContent = result.message || 'Appearance settings saved!';
+                settingsMessage.style.display = 'block';
+                settingsMessage.style.color = 'green';
+                // setTimeout(() => { settingsMessage.style.display = 'none'; }, 3000); // Timeout handled by main save
+            }
+            return true; // Indicate save success
+        } catch (error) {
+            console.error("Error saving appearance settings:", error);
+            if (settingsMessage) {
+                settingsMessage.textContent = 'Error saving appearance settings.';
+                settingsMessage.style.display = 'block';
+                settingsMessage.style.color = 'red';
+            }
+            return false; // Indicate save failed
+        }
+    }
+
+    // Event Listeners for Appearance
+    if (backgroundColorPicker) {
+        backgroundColorPicker.addEventListener('input', () => {
+            if (backgroundColorHex) backgroundColorHex.value = backgroundColorPicker.value;
+        });
+    }
+    if (backgroundColorHex) {
+        backgroundColorHex.addEventListener('input', () => {
+            if (backgroundColorHex.value.match(/^#[0-9a-fA-F]{6}$/i) || backgroundColorHex.value.match(/^#[0-9a-fA-F]{3}$/i)) {
+                if (backgroundColorPicker) backgroundColorPicker.value = backgroundColorHex.value;
+            }
+        });
     }
 
     settingsButton.addEventListener('click', openSettingsModal);
@@ -205,4 +319,5 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Initial calls
     loadScrapedDataPreview(); // Load preview data on page load
+    loadAppearanceSettings(); // Load appearance settings on page load
 });

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -216,15 +216,15 @@ body {
     margin-top: 0;
     color: #0277BD;
 }
-#settings-modal label {
+#settings-modal label { /* General label styling within the modal */
     display: block;
     margin-bottom: 8px;
     font-weight: 500;
 }
-#settings-modal input[type="text"] {
+#settings-modal input[type="text"] { /* General text input styling within the modal */
     width: calc(100% - 22px); /* Account for padding */
     padding: 10px;
-    margin-bottom: 20px;
+    margin-bottom: 20px; /* Default bottom margin for text inputs */
     border: 1px solid #CFD8DC;
     border-radius: 4px;
 }
@@ -240,7 +240,70 @@ body {
 #settings-modal button:hover {
     background-color: #0277BD;
 }
-#settings-message {
+#settings-message { /* This is the existing one, will be styled by new .settings-message too */
     margin-top: 15px;
     font-size: 0.9em;
+}
+
+/* --- Appended CSS for new settings elements --- */
+
+/* General item styling within the settings panel (modal) */
+.setting-item {
+    margin-bottom: 15px;
+    display: flex;
+    flex-direction: column; /* Stack label and input vertically */
+}
+
+.setting-item label { /* Specific to new items, if different from #settings-modal label */
+    margin-bottom: 5px;
+    font-weight: bold; /* Make it bold to differentiate if needed */
+    color: #555; /* Or inherit from body/modal. Default modal label is 500 weight, not bold */
+}
+
+.setting-item input[type="color"] {
+    width: 100px; /* Or adjust as needed */
+    height: 30px;
+    padding: 0; /* Remove default padding for color input */
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    cursor: pointer;
+    margin-bottom: 10px; /* Add some margin below color picker */
+}
+
+.setting-item input[type="text"] { /* This will apply to new text inputs in .setting-item */
+    padding: 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 1em; /* Ensure it's not too small */
+    /* width: auto; /* Let it be sized by flex or specific needs, not full width like timezone */
+    margin-bottom: 10px; /* Add some margin below text input for color HEX */
+}
+
+
+/* Settings message paragraph for feedback - this might enhance existing #settings-message */
+.settings-message { /* This class was added to the <p id="settings-message"> in index.html */
+    margin-top: 10px;
+    padding: 10px;
+    border-radius: 4px;
+    font-size: 0.9em;
+    text-align: center;
+}
+
+/* Specific styles for success/error messages if not handled by JS already for color */
+/* .settings-message.success { background-color: #e6ffed; color: #28a745; } */
+/* .settings-message.error { background-color: #ffe6e6; color: #dc3545; } */
+
+/* A horizontal rule for visual separation in settings modal */
+#settings-modal hr {
+    border: none;
+    border-top: 1px solid #eee;
+    margin-top: 20px;
+    margin-bottom: 20px;
+}
+
+#settings-modal h4 { /* For "Appearance" subheading */
+    margin-top: 0px;
+    margin-bottom: 15px;
+    font-weight: 500;
+    color: #0277BD; /* Match h3 style */
 }

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -54,10 +54,22 @@
         <div class="modal-content">
             <span class="close-button">&times;</span>
             <h3>Settings</h3>
-            <label for="timezone-input">Enter City or Timezone (e.g., "New York", "Europe/London"):</label>
-            <input type="text" id="timezone-input" placeholder="e.g., America/New_York">
+            <div class="setting-item">
+                <label for="timezone-input">Enter City or Timezone (e.g., "New York", "Europe/London"):</label>
+                <input type="text" id="timezone-input" placeholder="e.g., America/New_York">
+            </div>
+            <hr>
+            <h4>Appearance</h4>
+            <div class="setting-item">
+                <label for="backgroundColorPicker">Choose Background Color:</label>
+                <input type="color" id="backgroundColorPicker" value="#FFFFFF">
+            </div>
+            <div class="setting-item">
+                <label for="backgroundColorHex">Or Enter HEX Code:</label>
+                <input type="text" id="backgroundColorHex" placeholder="#FFFFFF" pattern="^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$">
+            </div>
             <button id="save-settings">Save Settings</button>
-            <p id="settings-message"></p>
+            <p id="settings-message" class="settings-message" style="display:none;"></p>
         </div>
     </div>
 


### PR DESCRIPTION
This commit introduces a new feature allowing you to customize the application's background color.

Key changes:
- **Backend (`webapp/app.py`):**
    - Added `/api/settings` endpoint (GET and POST) to manage and store the background color preference using Flask sessions.
- **Frontend (`webapp/templates/index.html`):**
    - Integrated color picker and HEX input fields into the existing settings modal.
- **JavaScript (`webapp/static/script.js`):**
    - Implemented logic to load and save color settings via the new API.
    - Added a function to calculate the luminance of the selected background color.
    - Automatically adjusts the body text color (to black or white) to ensure readability against the chosen background.
    - Synchronized the color picker and HEX input fields.
    - Integrated with the existing settings modal's save mechanism.
- **CSS (`webapp/static/style.css`):**
    - Added styles for the new input fields and labels within the settings modal to ensure they are displayed correctly.

You can now choose a custom background color, and the application will automatically adjust the text color for optimal contrast.